### PR TITLE
refactor: apply path aliases and configure Prettier formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,27 +1,29 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { UsersListComponent } from './pages/users-list/users-list.component';
-import { UserDetailsComponent } from './pages/user-details/user-details.component';
+import { UsersListComponent } from '@pages/users-list/users-list.component';
+import { UserDetailsComponent } from '@pages/user-details/user-details.component';
 
 const routes: Routes = [
-  { 
+  {
     path: '',
-    data: { breadcrumb: 'List'},
+    data: { breadcrumb: 'List' },
     children: [
-      { 
-        path: '', component: UsersListComponent ,
+      {
+        path: '',
+        component: UsersListComponent,
       },
       {
-        path: ':id', component: UserDetailsComponent, 
-        data: { breadcrumb: 'Profile'} 
-      }
-    ]
+        path: ':id',
+        component: UserDetailsComponent,
+        data: { breadcrumb: 'Profile' },
+      },
+    ],
   },
-  { path : '**' , redirectTo : '' , pathMatch : 'full'}
+  { path: '**', redirectTo: '', pathMatch: 'full' },
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,19 +3,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
-import { BreadcrumbComponent } from './components/breadcrumb/breadcrumb.component';
+import { BreadcrumbComponent } from '@components/breadcrumb/breadcrumb.component';
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    BreadcrumbComponent
-  ],
-  imports: [
-    BrowserModule,
-    AppRoutingModule,
-    BrowserAnimationsModule
-  ],
+  declarations: [AppComponent, BreadcrumbComponent],
+  imports: [BrowserModule, AppRoutingModule, BrowserAnimationsModule],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { BreadcrumbService, Breadcrumb } from '../../services/breadcrumb/breadcrumb.service';
+import { BreadcrumbService, Breadcrumb } from '@services/breadcrumb';
 import { Observable } from 'rxjs';
-import { slideInRightTrigger, zoomInTrigger } from 'src/app/animations';
+import { slideInRightTrigger, zoomInTrigger } from '@animation-presets/index'
 
 @Component({
   selector: 'app-breadcrumb',

--- a/src/app/pages/user-details/user-details.component.ts
+++ b/src/app/pages/user-details/user-details.component.ts
@@ -1,12 +1,12 @@
 import { Component, OnInit } from '@angular/core';
-import { UserService } from '../../services/user/user.service';
-import { MarkdownPipe } from "../../pipes/markdown/markdown.pipe";
+import { UserService } from '@services/user';
+import { MarkdownPipe } from "@pipes/markdown";
 import { CommonModule } from '@angular/common';
 import { catchError, Observable, of } from 'rxjs';
-import { UserData } from 'src/model/user-data';
+import { UserData } from '@model/index';
 import { ActivatedRoute, Router } from '@angular/router';
-import { isNumber } from 'src/utils/number';
-import { fadeInUpTrigger } from 'src/app/animations';
+import { isNumber } from '@utils/number';
+import { fadeInUpTrigger } from '@animation-presets/index';
 
 @Component({
   selector: 'app-user-details',

--- a/src/app/pages/users-list/users-list.component.ts
+++ b/src/app/pages/users-list/users-list.component.ts
@@ -1,7 +1,7 @@
-import {Component} from '@angular/core';
-import {UserService} from 'src/app/services/user/user.service';
+import { Component } from '@angular/core';
+import { UserService } from '@services/user';
 import { CommonModule } from '@angular/common';
-import { staggeredCardTrigger } from 'src/app/animations';
+import { staggeredCardTrigger } from '@animation-presets/index';
 
 @Component({
   selector: 'app-users-list',
@@ -9,11 +9,10 @@ import { staggeredCardTrigger } from 'src/app/animations';
   styleUrls: ['./users-list.component.scss'],
   standalone: true,
   imports: [CommonModule],
-  animations: [staggeredCardTrigger()]
+  animations: [staggeredCardTrigger()],
 })
 export class UsersListComponent {
   public readonly users$ = this.userService.getAll();
 
-  constructor(private readonly userService: UserService) {
-  }
+  constructor(private readonly userService: UserService) {}
 }

--- a/src/app/pipes/markdown/index.ts
+++ b/src/app/pipes/markdown/index.ts
@@ -1,0 +1,1 @@
+export * from './markdown.pipe';

--- a/src/app/pipes/markdown/markdown.pipe.ts
+++ b/src/app/pipes/markdown/markdown.pipe.ts
@@ -1,14 +1,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { renderMarkdown } from 'src/utils/string';
+import { renderMarkdown } from '@utils/string';
 
 @Pipe({
   name: 'markdown',
-  standalone: true
+  standalone: true,
 })
 export class MarkdownPipe implements PipeTransform {
   transform(markdown: string | null | undefined): string {
-    if(!markdown) return '';
+    if (!markdown) return '';
     return renderMarkdown(markdown);
   }
-
 }

--- a/src/app/services/breadcrumb/breadcrumb.service.ts
+++ b/src/app/services/breadcrumb/breadcrumb.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import { BehaviorSubject, filter } from 'rxjs';
-import { removeDuplicates } from 'src/utils/array';
+import { removeDuplicates } from '@utils/array';
 
 export interface Breadcrumb {
   label: string;
@@ -59,6 +59,6 @@ export class BreadcrumbService {
       return this.buildBreadcrumbs(route.firstChild, url, breadcrumbs);
     }
 
-    return removeDuplicates(breadcrumbs, bd => `${bd.label}|${bd.url}`);
+    return removeDuplicates(breadcrumbs, (bd) => `${bd.label}|${bd.url}`);
   }
 }

--- a/src/app/services/breadcrumb/index.ts
+++ b/src/app/services/breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './breadcrumb.service';

--- a/src/app/services/user/index.ts
+++ b/src/app/services/user/index.ts
@@ -1,0 +1,1 @@
+export * from './user.service';

--- a/src/app/services/user/user.service.ts
+++ b/src/app/services/user/user.service.ts
@@ -1,15 +1,14 @@
-import {Injectable} from '@angular/core';
-import {map, Observable, of} from 'rxjs';
-import {UserData, NewUserData} from 'src/model';
-import {UserPersistenceService} from './user-persistence.service';
-import {randomDelay} from 'src/utils/rxjs';
+import { Injectable } from '@angular/core';
+import { map, Observable, of } from 'rxjs';
+import { UserData, NewUserData } from 'src/model';
+import { UserPersistenceService } from './user-persistence.service';
+import { randomDelay } from '@utils/rxjs';
 
-
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class UserService {
-
-  constructor(private readonly userPersistenceService: UserPersistenceService) {
-  }
+  constructor(
+    private readonly userPersistenceService: UserPersistenceService
+  ) {}
 
   public getAll(): Observable<UserData[]> {
     return of(this.userPersistenceService.get()).pipe(randomDelay());
@@ -17,8 +16,8 @@ export class UserService {
 
   public findOneById(id: number): Observable<UserData> {
     return this.getAll().pipe(
-      map(all => {
-        const user = all.find(it => it.id === id);
+      map((all) => {
+        const user = all.find((it) => it.id === id);
         if (user) {
           return user;
         }
@@ -29,11 +28,13 @@ export class UserService {
 
   public create(userData: NewUserData): Observable<UserData> {
     const users = this.userPersistenceService.get();
-    const maxId = users.reduce((max, it) => Math.max(max, it.id), Number.MIN_SAFE_INTEGER);
+    const maxId = users.reduce(
+      (max, it) => Math.max(max, it.id),
+      Number.MIN_SAFE_INTEGER
+    );
     const id = maxId + 1;
-    const user: UserData = {...userData, id};
+    const user: UserData = { ...userData, id };
     this.userPersistenceService.put([...users, user]);
     return of(user).pipe(randomDelay());
   }
-
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>AngularCodingChallenge</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>AngularCodingChallenge</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,5 +8,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/src/model/user-data.ts
+++ b/src/model/user-data.ts
@@ -1,4 +1,4 @@
-import {NewUserData} from './new-user-data';
+import { NewUserData } from './new-user-data';
 
 export interface UserData extends NewUserData {
   id: number;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,6 +1,9 @@
-export function removeDuplicates<T>(arr: T[], keySelector: (item: T) => string): T[] {
+export function removeDuplicates<T>(
+  arr: T[],
+  keySelector: (item: T) => string
+): T[] {
   const seen = new Set<string>();
-  return arr.filter(item => {
+  return arr.filter((item) => {
     const key = keySelector(item);
     if (seen.has(key)) {
       return false;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './array';
+export * from './number';
+export * from './rxjs';
+export * from './string';

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,4 +1,4 @@
 export function isNumber(input: string): boolean {
-    if (input.trim() === '') return false;
-    return !isNaN(Number(input));
+  if (input.trim() === '') return false;
+  return !isNaN(Number(input));
 }

--- a/src/utils/rxjs.ts
+++ b/src/utils/rxjs.ts
@@ -1,5 +1,8 @@
-import {delay, MonoTypeOperatorFunction} from 'rxjs';
+import { delay, MonoTypeOperatorFunction } from 'rxjs';
 
-export function randomDelay<T>(minDelay = 100, maxDelay = 300): MonoTypeOperatorFunction<T> {
-  return delay(minDelay + Math.random() * (maxDelay - minDelay))
+export function randomDelay<T>(
+  minDelay = 100,
+  maxDelay = 300
+): MonoTypeOperatorFunction<T> {
+  return delay(minDelay + Math.random() * (maxDelay - minDelay));
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,4 +1,4 @@
-import {marked} from 'marked';
+import { marked } from 'marked';
 
 export function renderMarkdown(markdown: string): string {
   return marked.parse(markdown);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,18 @@
     "lib": [
       "es2020",
       "dom"
-    ]
+    ],
+    "paths": {
+      "@components/*": ["src/app/components/*"],
+      "@services/*": ["src/app/services/*"],
+      "@pipes/*": ["src/app/pipes/*"],
+      "@pages/*": ["src/app/pages/*"],
+      "@animation-presets/*": ["src/app/animations/*"],
+      "@model/*": ["src/model/*"],
+      "@environments/*": ["src/environments/*"],
+      "@utils/*": ["src/utils/*"],
+      "@assets/*": ["src/assets/*"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
- Updated tsconfig.json with path aliases for cleaner and consistent imports
- Refactored modules, components, services, pipes, and pages to use new aliases
- Added VSCode settings.json to set Prettier as the default formatter and enable format on save
- Formatted codebase using Prettier for consistency